### PR TITLE
Ensure object-dumper prebackuppod has writeable home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - backup of individual objects ([#3])
 - Option to disable the component via hierarchy
+- Fix slow object dumping on OpenShift 4 ([#6])
 
 [Unreleased]: https://github.com/projectsyn/component-cluster-backup/compare/11573bc...HEAD
 
 [#3]: https://github.com/projectsyn/component-cluster-backup/pull/3
+[#6]: https://github.com/projectsyn/component-cluster-backup/pull/6

--- a/component/object.jsonnet
+++ b/component/object.jsonnet
@@ -48,10 +48,20 @@ local objectDumper =
           serviceAccountName: sa.metadata.name,
           containers: [
             pod.spec.pod.spec.containers[0] {
+              env: [
+                {
+                  name: 'HOME',
+                  value: '/home/dumper',
+                },
+              ],
               volumeMounts: [
                 {
                   name: 'data',
                   mountPath: '/data',
+                },
+                {
+                  name: 'home',
+                  mountPath: '/home/dumper',
                 },
                 {
                   name: 'config',
@@ -63,6 +73,10 @@ local objectDumper =
           volumes: [
             {
               name: 'data',
+              emptyDir: {},
+            },
+            {
+              name: 'home',
               emptyDir: {},
             },
             {


### PR DESCRIPTION
After some experimentation with [FlowSchemas], we found that the API interactions get throttled even when running the PrebackupPod with the `system` flow priority (same level as the Kubelets).

We then found that the throttling is caused because `kubectl` isn't able to create its API cache (in `$HOME/.kube/cache` and
`$HOME/.kube/http-cache`) on OpenShift 4, because we don't set `$HOME` to a writeable location, and the pod runs as an unprivileged user on OpenShift.

~~On plain Kubernetes the issue doesn't occur, because the PrebackupPod runs as root there, and thus can write to `/.kube`.~~ The issue actually occurs on plain Kubernetes too, as the PrebackupPod runs as non-root there as well. However, the throttling appears less severe, as the jobs take only ~15 minutes.

This commit ensures that `$HOME` is set to `/home/dumper` and that `/home/dumper` is writeable, by mounting an emptyDir volume there.

Fixes projectsyn/k8s-object-dumper#8

[FlowSchemas]: https://kubernetes.io/docs/concepts/cluster-administration/flow-control

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
