### PR TITLE
Revert "Update object-dumper image default tag to v0.2.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update object-dumper image default tag to v0.1.1 ([#8])
-- Update object-dumper image default tag to v0.2.0 ([#9])
 
 [Unreleased]: https://github.com/projectsyn/component-cluster-backup/compare/11573bc...HEAD
 
@@ -23,4 +22,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#6]: https://github.com/projectsyn/component-cluster-backup/pull/6
 [#7]: https://github.com/projectsyn/component-cluster-backup/pull/7
 [#8]: https://github.com/projectsyn/component-cluster-backup/pull/8
-[#9]: https://github.com/projectsyn/component-cluster-backup/pull/9

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -48,4 +48,4 @@ parameters:
     images:
       object_dumper:
         image: docker.io/projectsyn/k8s-object-dumper
-        tag: v0.2.0
+        tag: v0.1.1


### PR DESCRIPTION
The v0.2.0 tag uses kubectl binary that is too new to be used with the
current clusters and completely breaks the cluster-backups. This needs
to be reverted until the new image is ready

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Update the ./CHANGELOG.md.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
