### PR TITLE
Revert to object-dumper image default tag to v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update object-dumper image default tag to v0.1.1 ([#8])
 - Update object-dumper image default tag to v0.2.0 ([#9])
+- Revert object-dumper image default tag to v0.1.1 ([#10])
 
 [Unreleased]: https://github.com/projectsyn/component-cluster-backup/compare/11573bc...HEAD
 
@@ -24,3 +25,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#7]: https://github.com/projectsyn/component-cluster-backup/pull/7
 [#8]: https://github.com/projectsyn/component-cluster-backup/pull/8
 [#9]: https://github.com/projectsyn/component-cluster-backup/pull/9
+[#10]: https://github.com/projectsyn/component-cluster-backup/pull/10

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -48,4 +48,4 @@ parameters:
     images:
       object_dumper:
         image: docker.io/projectsyn/k8s-object-dumper
-        tag: v0.2.0
+        tag: v0.1.1


### PR DESCRIPTION
The latest object-dumper image uses a kubectl binary that is too new for
most of our clusters and therefore breaks the cluster-backup completely

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
