### PR TITLE
Fix node-selector

### DIFF
--- a/component/ocp4-etcd.jsonnet
+++ b/component/ocp4-etcd.jsonnet
@@ -11,7 +11,7 @@ local privilegedNamespace = kube.Namespace(namespaceName) {
   metadata+: {
     annotations+: {
       // Jobs must be allowed on master nodes to backup etcd
-      'openshift.io/node-selector': 'node-role.kubernetes.io/master=',
+      'openshift.io/node-selector': '',
     },
   },
 };
@@ -134,6 +134,9 @@ local etcdBackup =
               name: 'backup',
             },
           ],
+          nodeSelector: {
+            'node-role.kubernetes.io/master': '',
+          },
           tolerations: [
             {
               key: 'node-role.kubernetes.io/master',

--- a/tests/golden/defaults/cluster-backup/cluster-backup/20_ocp4_etcd.yaml
+++ b/tests/golden/defaults/cluster-backup/cluster-backup/20_ocp4_etcd.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    openshift.io/node-selector: node-role.kubernetes.io/master=
+    openshift.io/node-selector: ''
   labels:
     app.kubernetes.io/component: cluster-backup
     app.kubernetes.io/managed-by: commodore
@@ -124,6 +124,8 @@ spec:
               name: backup
             - mountPath: /host
               name: host
+      nodeSelector:
+        node-role.kubernetes.io/master: ''
       serviceAccountName: etcd-backup
       terminationGracePeriodSeconds: 30
       tolerations:


### PR DESCRIPTION
This reverts commit b8001882928837a8d129781beec31f34c270962f.

K8up jobs can't run on master nodes, they are lacking the required tolerations.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
