### PR TITLE
Fix bashism and remove directory structure from tar

### DIFF
--- a/component/ocp4-etcd.jsonnet
+++ b/component/ocp4-etcd.jsonnet
@@ -63,7 +63,7 @@ local etcdBackup =
   local pod = backup.PreBackupPod(
     'etcd-backup',
     '%s/%s:%s' % [ image.registry, image.image, image.tag ],
-    'tar czf - /host/mnt/backup/*.{db,tar.gz}',
+    'tar czf - -C /host/mnt/backup/ .',
     fileext='.tar.gz'
   );
   pod {

--- a/tests/golden/defaults/cluster-backup/cluster-backup/20_ocp4_etcd.yaml
+++ b/tests/golden/defaults/cluster-backup/cluster-backup/20_ocp4_etcd.yaml
@@ -70,7 +70,7 @@ metadata:
   name: etcd-backup
   namespace: syn-cluster-backup-etcd
 spec:
-  backupCommand: tar czf - /host/mnt/backup/*.{db,tar.gz}
+  backupCommand: tar czf - -C /host/mnt/backup/ .
   fileExtension: .tar.gz
   pod:
     spec:


### PR DESCRIPTION
Brace expansion `{a,b}` is not supported in `dash` or `busybox`. It is also not needed since we always create a new empty dir.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
