### PR TITLE
Fix tenant name reclass references

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,11 +6,11 @@ parameters:
     enabled: true
     namespace: syn-cluster-backup
     keepjobs: 5
-    password: '?{vaultkv:${customer:name}/${cluster:name}/cluster-backup/password}'
+    password: '?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/password}'
     bucket:
       name: '${cluster:name}-cluster-backup'
-      accesskey: '?{vaultkv:${customer:name}/${cluster:name}/cluster-backup/s3_access_key}'
-      secretkey: '?{vaultkv:${customer:name}/${cluster:name}/cluster-backup/s3_secret_key}'
+      accesskey: '?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/s3_access_key}'
+      secretkey: '?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/s3_secret_key}'
     known_to_fail:
       - '.+mutators'
       - '.+reviews'

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -34,7 +34,7 @@ This bucket will be used to store the backups.
 
 [horizontal]
 type:: string
-default:: `'?{vaultkv:${customer:name}/${cluster:name}/cluster-backup/s3_access_key}'`
+default:: `'?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/s3_access_key}'`
 
 The access key needed to access the storage bucket.
 The default is a reference to a secret within Vault.
@@ -51,7 +51,7 @@ The name of the storage bucket.
 
 [horizontal]
 type:: string
-default:: `?{vaultkv:${customer:name}/${cluster:name}/cluster-backup/s3_secret_key}`
+default:: `?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/s3_secret_key}`
 
 The secret key needed to access the storage bucket.
 The default is a reference to a secret within Vault.
@@ -106,7 +106,7 @@ Number of backup jobs to keep.
 
 [horizontal]
 type:: string
-default:: `?{vaultkv:${customer:name}/${cluster:name}/cluster-backup/password}'`
+default:: `?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/password}'`
 
 Password used to encrypt the backup.
 The default is a reference to a secret within Vault.


### PR DESCRIPTION
We've deprecated `customer.name` a while ago.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
