### PR TITLE
Adjust prune schedules to avoid conflicts on OCP4

### DIFF
--- a/component/ocp4-etcd.jsonnet
+++ b/component/ocp4-etcd.jsonnet
@@ -154,4 +154,9 @@ local etcdBackup =
   serviceAccount,
   scc,
   etcdBackup,
-] + schedule.Schedule('etcd', namespaceName, '%d 3 * * *' % schedule.RandomMinute(namespaceName))
+] + schedule.Schedule(
+  'etcd',
+  namespaceName,
+  '%d 3 * * *' % schedule.RandomMinute(namespaceName),
+  '20 */4 * * *'
+)

--- a/component/schedule.libsonnet
+++ b/component/schedule.libsonnet
@@ -9,7 +9,7 @@ local params = inv.parameters.cluster_backup;
 local minute(namespace) =
   std.foldl(function(x, y) x + y, std.encodeUTF8(std.md5(inv.parameters.cluster.name + namespace)), 0) % 60;
 
-local buildSchedule(name, namespace, backupSchedule) =
+local buildSchedule(name, namespace, backupSchedule, pruneSchedule='10 */4 * * *') =
   local backupSecret = kube.Secret('%s-backup-password' % name) {
     metadata+: {
       namespace: namespace,
@@ -49,7 +49,7 @@ local buildSchedule(name, namespace, backupSchedule) =
     backupkey=backupSecretRef,
     s3secret=bucketSecretRef,
     create_bucket=false,
-  ).schedule + backup.PruneSpec('10 */4 * * *', 30, 20) {
+  ).schedule + backup.PruneSpec(pruneSchedule, 30, 20) {
     metadata+: {
       namespace: namespace,
     },

--- a/tests/golden/defaults/cluster-backup/cluster-backup/20_ocp4_etcd.yaml
+++ b/tests/golden/defaults/cluster-backup/cluster-backup/20_ocp4_etcd.yaml
@@ -207,4 +207,4 @@ spec:
     retention:
       keepDaily: 30
       keepLast: 20
-    schedule: 10 */4 * * *
+    schedule: 20 */4 * * *


### PR DESCRIPTION
On OpenShift 4, the component configures two K8up schedules, both of which had the same prune cron schedule until now.

This commit adjust the prune cron schedule for the etcd backups on OpenShift 4 to be 10 minutes offset from the cluster objects backup. This should avoid race conditions between two restic prune jobs trying to delete each other's locks.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
