### PR TITLE
Use the new Go object dumper

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -23,7 +23,9 @@ parameters:
       ssh_private_key: '?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/ssh_private_key}'
       ssh_public_key: '?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/ssh_public_key}'
       ssh_known_hosts: ''
-    ignored: []
+    ignored:
+      # OpenShift fucked up and shows the list api as enabled in the API-Discovery
+      - projectrequests.project.openshift.io
     must_exist: []
     images:
       object_dumper:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -23,44 +23,32 @@ parameters:
       ssh_private_key: '?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/ssh_private_key}'
       ssh_public_key: '?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/ssh_public_key}'
       ssh_known_hosts: ''
-    known_to_fail:
-      - '.+mutators'
-      - '.+reviews'
-      - '.+validators'
-      - 'bindings'
-      - 'deploymentconfigrollbacks'
-      - 'imagesignatures'
-      - 'imagestreamimages'
-      - 'imagestreamimports'
-      - 'imagestreammappings'
-      - 'mutations'
-      - 'projectrequests'
-      - 'useridentitymappings'
-      - 'validations'
+    ignored: []
     must_exist:
       - 'configmaps'
-      - 'daemonsets'
-      - 'deployments'
+      - 'daemonsets.apps'
+      - 'deployments.apps'
       - 'endpoints'
-      - 'horizontalpodautoscalers'
-      - 'ingresses'
-      - 'jobs'
+      - 'horizontalpodautoscalers.autoscaling'
+      - 'ingresses.networking.k8s.io'
+      - 'jobs.batch'
       - 'limitranges'
       - 'namespaces'
       - 'nodes'
       - 'persistentvolumeclaims'
       - 'persistentvolumes'
-      - 'replicasets'
+      - 'replicasets.apps'
       - 'resourcequotas'
-      - 'roles'
+      - 'roles.rbac.authorization.k8s.io'
       - 'secrets'
       - 'serviceaccounts'
       - 'services'
-      - 'statefulsets'
+      - 'statefulsets.apps'
     images:
       object_dumper:
-        image: docker.io/projectsyn/k8s-object-dumper
-        tag: v0.2.3
+        registry: ghcr.io
+        image: projectsyn/k8s-object-dumper
+        tag: v0.3.0
       etcd_backup:
         registry: docker.io
         image: debian

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -24,26 +24,7 @@ parameters:
       ssh_public_key: '?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/ssh_public_key}'
       ssh_known_hosts: ''
     ignored: []
-    must_exist:
-      - 'configmaps'
-      - 'daemonsets.apps'
-      - 'deployments.apps'
-      - 'endpoints'
-      - 'horizontalpodautoscalers.autoscaling'
-      - 'ingresses.networking.k8s.io'
-      - 'jobs.batch'
-      - 'limitranges'
-      - 'namespaces'
-      - 'nodes'
-      - 'persistentvolumeclaims'
-      - 'persistentvolumes'
-      - 'replicasets.apps'
-      - 'resourcequotas'
-      - 'roles.rbac.authorization.k8s.io'
-      - 'secrets'
-      - 'serviceaccounts'
-      - 'services'
-      - 'statefulsets.apps'
+    must_exist: []
     images:
       object_dumper:
         registry: ghcr.io

--- a/component/scripts/dump.sh
+++ b/component/scripts/dump.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+output_dir="/data"
+
+k8s-object-dumper  "-dir" "${output_dir}" "$@"
+
+( cd "${output_dir}" && tar c . )

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -237,36 +237,20 @@ The discovery automatically filters them out.
 
 [horizontal]
 type:: list
-default::
-+
-[source,yaml]
-----
-- 'configmaps'
-- 'daemonsets.apps'
-- 'deployments.apps'
-- 'endpoints'
-- 'horizontalpodautoscalers.autoscaling'
-- 'ingresses.networking.k8s.io'
-- 'jobs.batch'
-- 'limitranges'
-- 'namespaces'
-- 'nodes'
-- 'persistentvolumeclaims'
-- 'persistentvolumes'
-- 'replicasets.apps'
-- 'resourcequotas'
-- 'roles.rbac.authorization.k8s.io'
-- 'secrets'
-- 'serviceaccounts'
-- 'services'
-- 'statefulsets.apps'
-----
+default:: `[]`
 
 Resource types which must exist on any Kubernetes cluster.
 Used to sanity-check the backup process.
 
 They must be fully qualified resource types `<resource>.<group>`, e.g. `deployments.apps`.
 
+[IMPORTANT]
+====
+As of https://github.com/k8up-io/k8up/releases/tag/v2.11.1[k8up v2.11.1] the errors from backup commands are ignored (https://github.com/k8up-io/k8up/issues/910[issue]).
+
+This means that if a resource type listed in `must_exist` is not found, the backup will be created but it will be empty.
+For this reason, and because we trust the discovery process of the new dumper, we set the default value to an empty list and recommend to not use this feature until the issue is resolved.
+====
 
 == Example
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -217,30 +217,21 @@ default:: `'?{vaultkv:${cluster:tenant}/${cluster:name}/cluster-backup/password}
 Password used to encrypt the backup.
 The default is a reference to a secret within Vault.
 
-== `known_to_fail`
+
+== `ignored`
 
 [horizontal]
 type:: list
-default::
-+
-[source,yaml]
-----
-- '.+mutators'
-- '.+reviews'
-- '.+validators'
-- 'bindings'
-- 'deploymentconfigrollbacks'
-- 'imagesignatures'
-- 'imagestreamimages'
-- 'imagestreamimports'
-- 'imagestreammappings'
-- 'mutations'
-- 'projectrequests'
-- 'useridentitymappings'
-- 'validations'
-----
+default:: `[]`
 
-Resource types which are known to produce errors when doing `kubectl get <resource>`.
+Resource types which will not be backed up.
+
+[NOTE]
+====
+It is no longer necessary to ignore resources with no `list` verb.
+The discovery automatically filters them out.
+====
+
 
 == `must_exist`
 
@@ -251,27 +242,31 @@ default::
 [source,yaml]
 ----
 - 'configmaps'
-- 'daemonsets'
-- 'deployments'
+- 'daemonsets.apps'
+- 'deployments.apps'
 - 'endpoints'
-- 'horizontalpodautoscalers'
-- 'ingresses'
-- 'jobs'
+- 'horizontalpodautoscalers.autoscaling'
+- 'ingresses.networking.k8s.io'
+- 'jobs.batch'
 - 'limitranges'
 - 'namespaces'
 - 'nodes'
 - 'persistentvolumeclaims'
 - 'persistentvolumes'
-- 'replicasets'
+- 'replicasets.apps'
 - 'resourcequotas'
-- 'roles'
+- 'roles.rbac.authorization.k8s.io'
 - 'secrets'
 - 'serviceaccounts'
 - 'services'
-- 'statefulsets'
+- 'statefulsets.apps'
 ----
 
 Resource types which must exist on any Kubernetes cluster.
+Used to sanity-check the backup process.
+
+They must be fully qualified resource types `<resource>.<group>`, e.g. `deployments.apps`.
+
 
 == Example
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -222,13 +222,20 @@ The default is a reference to a secret within Vault.
 
 [horizontal]
 type:: list
-default:: `[]`
+default::
++
+[source,yaml]
+----
+ignored:
+  # OpenShift fucked up and shows the list api as enabled in the API-Discovery
+  - projectrequests.project.openshift.io
+----
 
 Resource types which will not be backed up.
 
 [NOTE]
 ====
-It is no longer necessary to ignore resources with no `list` verb.
+It is usually no longer necessary to ignore resources with no `list` verb.
 The discovery automatically filters them out.
 ====
 

--- a/tests/golden/defaults/cluster-backup/cluster-backup/10_object.yaml
+++ b/tests/golden/defaults/cluster-backup/cluster-backup/10_object.yaml
@@ -91,12 +91,7 @@ metadata:
   name: object-dumper
   namespace: syn-cluster-backup
 spec:
-  backupCommand: /scripts/dump.sh -must-exist=configmaps -must-exist=daemonsets.apps
-    -must-exist=deployments.apps -must-exist=endpoints -must-exist=horizontalpodautoscalers.autoscaling
-    -must-exist=ingresses.networking.k8s.io -must-exist=jobs.batch -must-exist=limitranges
-    -must-exist=namespaces -must-exist=nodes -must-exist=persistentvolumeclaims -must-exist=persistentvolumes
-    -must-exist=replicasets.apps -must-exist=resourcequotas -must-exist=roles.rbac.authorization.k8s.io
-    -must-exist=secrets -must-exist=serviceaccounts -must-exist=services -must-exist=statefulsets.apps
+  backupCommand: '/scripts/dump.sh '
   fileExtension: .tar
   pod:
     spec:

--- a/tests/golden/defaults/cluster-backup/cluster-backup/10_object.yaml
+++ b/tests/golden/defaults/cluster-backup/cluster-backup/10_object.yaml
@@ -91,7 +91,7 @@ metadata:
   name: object-dumper
   namespace: syn-cluster-backup
 spec:
-  backupCommand: '/scripts/dump.sh '
+  backupCommand: /scripts/dump.sh -ignore=projectrequests.project.openshift.io
   fileExtension: .tar
   pod:
     spec:

--- a/tests/golden/defaults/cluster-backup/cluster-backup/10_object.yaml
+++ b/tests/golden/defaults/cluster-backup/cluster-backup/10_object.yaml
@@ -61,49 +61,24 @@ subjects:
 ---
 apiVersion: v1
 data:
-  known-to-fail: |-
-    .+mutators
-    .+reviews
-    .+validators
-    bindings
-    deploymentconfigrollbacks
-    imagesignatures
-    imagestreamimages
-    imagestreamimports
-    imagestreammappings
-    mutations
-    projectrequests
-    useridentitymappings
-    validations
-  must-exist: |-
-    configmaps
-    daemonsets
-    deployments
-    endpoints
-    horizontalpodautoscalers
-    ingresses
-    jobs
-    limitranges
-    namespaces
-    nodes
-    persistentvolumeclaims
-    persistentvolumes
-    replicasets
-    resourcequotas
-    roles
-    secrets
-    serviceaccounts
-    services
-    statefulsets
+  dump.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    output_dir="/data"
+
+    k8s-object-dumper  "-dir" "${output_dir}" "$@"
+
+    ( cd "${output_dir}" && tar c . )
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app.kubernetes.io/component: cluster-backup
     app.kubernetes.io/managed-by: commodore
-    app.kubernetes.io/name: object-dumper
-    name: object-dumper
-  name: object-dumper
+    app.kubernetes.io/name: object-dumper-script
+    name: object-dumper-script
+  name: object-dumper-script
   namespace: syn-cluster-backup
 ---
 apiVersion: k8up.io/v1
@@ -116,8 +91,13 @@ metadata:
   name: object-dumper
   namespace: syn-cluster-backup
 spec:
-  backupCommand: /usr/local/bin/dump-objects -sd /data
-  fileExtension: .tar.gz
+  backupCommand: /scripts/dump.sh -must-exist=configmaps -must-exist=daemonsets.apps
+    -must-exist=deployments.apps -must-exist=endpoints -must-exist=horizontalpodautoscalers.autoscaling
+    -must-exist=ingresses.networking.k8s.io -must-exist=jobs.batch -must-exist=limitranges
+    -must-exist=namespaces -must-exist=nodes -must-exist=persistentvolumeclaims -must-exist=persistentvolumes
+    -must-exist=replicasets.apps -must-exist=resourcequotas -must-exist=roles.rbac.authorization.k8s.io
+    -must-exist=secrets -must-exist=serviceaccounts -must-exist=services -must-exist=statefulsets.apps
+  fileExtension: .tar
   pod:
     spec:
       containers:
@@ -129,7 +109,7 @@ spec:
           env:
             - name: HOME
               value: /home/dumper
-          image: docker.io/projectsyn/k8s-object-dumper:v0.2.3
+          image: ghcr.io/projectsyn/k8s-object-dumper:v0.3.0
           imagePullPolicy: IfNotPresent
           name: object-dumper
           ports: []
@@ -140,8 +120,8 @@ spec:
               name: data
             - mountPath: /home/dumper
               name: home
-            - mountPath: /usr/local/share/k8s-object-dumper
-              name: config
+            - mountPath: /scripts
+              name: scripts
       imagePullSecrets: []
       initContainers: []
       serviceAccountName: object-backup
@@ -152,8 +132,9 @@ spec:
         - emptyDir: {}
           name: home
         - configMap:
-            name: object-dumper
-          name: config
+            defaultMode: 493
+            name: object-dumper-script
+          name: scripts
 ---
 apiVersion: v1
 data: {}

--- a/tests/golden/sftp/cluster-backup/cluster-backup/10_object.yaml
+++ b/tests/golden/sftp/cluster-backup/cluster-backup/10_object.yaml
@@ -91,12 +91,7 @@ metadata:
   name: object-dumper
   namespace: syn-cluster-backup
 spec:
-  backupCommand: /scripts/dump.sh -must-exist=configmaps -must-exist=daemonsets.apps
-    -must-exist=deployments.apps -must-exist=endpoints -must-exist=horizontalpodautoscalers.autoscaling
-    -must-exist=ingresses.networking.k8s.io -must-exist=jobs.batch -must-exist=limitranges
-    -must-exist=namespaces -must-exist=nodes -must-exist=persistentvolumeclaims -must-exist=persistentvolumes
-    -must-exist=replicasets.apps -must-exist=resourcequotas -must-exist=roles.rbac.authorization.k8s.io
-    -must-exist=secrets -must-exist=serviceaccounts -must-exist=services -must-exist=statefulsets.apps
+  backupCommand: '/scripts/dump.sh '
   fileExtension: .tar
   pod:
     spec:

--- a/tests/golden/sftp/cluster-backup/cluster-backup/10_object.yaml
+++ b/tests/golden/sftp/cluster-backup/cluster-backup/10_object.yaml
@@ -91,7 +91,7 @@ metadata:
   name: object-dumper
   namespace: syn-cluster-backup
 spec:
-  backupCommand: '/scripts/dump.sh '
+  backupCommand: /scripts/dump.sh -ignore=projectrequests.project.openshift.io
   fileExtension: .tar
   pod:
     spec:

--- a/tests/golden/sftp/cluster-backup/cluster-backup/10_object.yaml
+++ b/tests/golden/sftp/cluster-backup/cluster-backup/10_object.yaml
@@ -61,49 +61,24 @@ subjects:
 ---
 apiVersion: v1
 data:
-  known-to-fail: |-
-    .+mutators
-    .+reviews
-    .+validators
-    bindings
-    deploymentconfigrollbacks
-    imagesignatures
-    imagestreamimages
-    imagestreamimports
-    imagestreammappings
-    mutations
-    projectrequests
-    useridentitymappings
-    validations
-  must-exist: |-
-    configmaps
-    daemonsets
-    deployments
-    endpoints
-    horizontalpodautoscalers
-    ingresses
-    jobs
-    limitranges
-    namespaces
-    nodes
-    persistentvolumeclaims
-    persistentvolumes
-    replicasets
-    resourcequotas
-    roles
-    secrets
-    serviceaccounts
-    services
-    statefulsets
+  dump.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    output_dir="/data"
+
+    k8s-object-dumper  "-dir" "${output_dir}" "$@"
+
+    ( cd "${output_dir}" && tar c . )
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app.kubernetes.io/component: cluster-backup
     app.kubernetes.io/managed-by: commodore
-    app.kubernetes.io/name: object-dumper
-    name: object-dumper
-  name: object-dumper
+    app.kubernetes.io/name: object-dumper-script
+    name: object-dumper-script
+  name: object-dumper-script
   namespace: syn-cluster-backup
 ---
 apiVersion: k8up.io/v1
@@ -116,8 +91,13 @@ metadata:
   name: object-dumper
   namespace: syn-cluster-backup
 spec:
-  backupCommand: /usr/local/bin/dump-objects -sd /data
-  fileExtension: .tar.gz
+  backupCommand: /scripts/dump.sh -must-exist=configmaps -must-exist=daemonsets.apps
+    -must-exist=deployments.apps -must-exist=endpoints -must-exist=horizontalpodautoscalers.autoscaling
+    -must-exist=ingresses.networking.k8s.io -must-exist=jobs.batch -must-exist=limitranges
+    -must-exist=namespaces -must-exist=nodes -must-exist=persistentvolumeclaims -must-exist=persistentvolumes
+    -must-exist=replicasets.apps -must-exist=resourcequotas -must-exist=roles.rbac.authorization.k8s.io
+    -must-exist=secrets -must-exist=serviceaccounts -must-exist=services -must-exist=statefulsets.apps
+  fileExtension: .tar
   pod:
     spec:
       containers:
@@ -129,7 +109,7 @@ spec:
           env:
             - name: HOME
               value: /home/dumper
-          image: docker.io/projectsyn/k8s-object-dumper:v0.2.3
+          image: ghcr.io/projectsyn/k8s-object-dumper:v0.3.0
           imagePullPolicy: IfNotPresent
           name: object-dumper
           ports: []
@@ -140,8 +120,8 @@ spec:
               name: data
             - mountPath: /home/dumper
               name: home
-            - mountPath: /usr/local/share/k8s-object-dumper
-              name: config
+            - mountPath: /scripts
+              name: scripts
       imagePullSecrets: []
       initContainers: []
       serviceAccountName: object-backup
@@ -152,8 +132,9 @@ spec:
         - emptyDir: {}
           name: home
         - configMap:
-            name: object-dumper
-          name: config
+            defaultMode: 493
+            name: object-dumper-script
+          name: scripts
 ---
 apiVersion: v1
 data: {}


### PR DESCRIPTION
* The output changes from `tar.gz` to uncompressed `tar` to allow restic to better compress and deduplicate.
* `known_to_fail` is no longer needed and removed.
* `must_exist` now needs to be fully qualified in the format of `<resource>[.<group>]`
* `must_exist` is empty by default because of https://github.com/k8up-io/k8up/issues/910 and because we trust the new discovery process.  
* `object_dumper` image ref is now in the Project Syn best practice format.