### PR TITLE
Adjust OCP4 etcd backup SCC to have `allowedCapabilities: null`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @projectsyn/tarazed
+* @projectsyn/aldebaran-tech

--- a/component/ocp4-etcd.jsonnet
+++ b/component/ocp4-etcd.jsonnet
@@ -26,7 +26,7 @@ local scc = kube._Object('security.openshift.io/v1', 'SecurityContextConstraints
   allowPrivilegedContainer: true,
   allowHostNetwork: true,
   allowHostDirVolumePlugin: true,
-  allowedCapabilities: [],
+  allowedCapabilities: null,
   allowHostPorts: false,
   allowHostPID: false,
   allowHostIPC: false,

--- a/tests/golden/defaults/cluster-backup/cluster-backup/20_ocp4_etcd.yaml
+++ b/tests/golden/defaults/cluster-backup/cluster-backup/20_ocp4_etcd.yaml
@@ -28,7 +28,7 @@ allowHostNetwork: true
 allowHostPID: false
 allowHostPorts: false
 allowPrivilegedContainer: true
-allowedCapabilities: []
+allowedCapabilities: null
 apiVersion: security.openshift.io/v1
 defaultAddCapabilities: []
 fsGroup:

--- a/tests/golden/sftp/cluster-backup/cluster-backup/20_ocp4_etcd.yaml
+++ b/tests/golden/sftp/cluster-backup/cluster-backup/20_ocp4_etcd.yaml
@@ -28,7 +28,7 @@ allowHostNetwork: true
 allowHostPID: false
 allowHostPorts: false
 allowPrivilegedContainer: true
-allowedCapabilities: []
+allowedCapabilities: null
 apiVersion: security.openshift.io/v1
 defaultAddCapabilities: []
 fsGroup:


### PR DESCRIPTION
`allowedCapabilities: []` and `allowedCapabilities: null` are functionally equivalent as far as I can tell, but the OpenShift compliance operator doesn't like the variant with the empty array.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
